### PR TITLE
add 'explicit_plugins' option

### DIFF
--- a/lib/App/GitHooks.pm
+++ b/lib/App/GitHooks.pm
@@ -362,6 +362,27 @@ they will be ignored.
 
 	force_plugins = App::GitHooks::Plugin::ValidatePODFormat, App::GitHooks::Plugin::RequireCommitMessage
 
+=item * explicit_plugins
+
+If present and set to a C<true> value, the value of C<force_plugins> will be
+derived from the plugin sections present in the configuration file. 
+
+For example:
+
+    explicit_plugins=1
+
+    [RequireTicketID]
+
+    [ValidatePODFormat]
+
+is equivalent to
+
+    force_plugins=RequireTicketID, ValidatePODFormat
+
+    [RequireTicketID]
+
+    [ValidatePODFormat]
+
 =back
 
 

--- a/lib/App/GitHooks/Config.pm
+++ b/lib/App/GitHooks/Config.pm
@@ -71,11 +71,20 @@ sub new
 
 	bless( $self, $class );
 
+    $self->_explicit_plugins;
+
 	# Store meta-information for future reference.
 	$self->{'__source'} = $source;
 	$self->{'__path'} = $file;
 
 	return $self;
+}
+
+sub _explicit_plugins {
+    my $self = shift;
+    
+    $self->{'_'}{force_plugins} = join ',', grep { $_ ne '_' } keys %$self
+        if $self->{'_'}{explicit_plugins};
 }
 
 


### PR DESCRIPTION
Makes the system look at the plugin sections, and use
that list as the list of plugins we want to use.