### PR TITLE
Replace has_git by test_requires_git

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -50,6 +50,7 @@ my $builder = $class->new(
 		'Test::Exception'       => 0,
 		'Test::FailWarnings'    => 0,
 		'Test::Git'             => 0,
+		'Test::Requires::Git'   => 1.005,
 		'Test::More'            => 0,
 		'Test::Type'            => 1.002000,
 	},

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -24,6 +24,7 @@ WriteMakefile
                    'Try::Tiny' => 0,
                    'Getopt::Long' => 0,
                    'Test::Git' => 0,
+                   'Test::Requires::Git' => 1.005,
                    'Test::Exception' => 0,
                    'Term::ANSIColor' => 0,
                    'Test::FailWarnings' => 0,

--- a/lib/App/GitHooks/Test.pm
+++ b/lib/App/GitHooks/Test.pm
@@ -17,6 +17,7 @@ use File::Temp;
 use Path::Tiny qw();
 use Test::Exception;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 # Internal dependencies.
@@ -557,7 +558,7 @@ sub test_hook
 		if $hook_name !~ /^[\w-]+$/;
 
 	# Bail out if Git isn't available.
-	has_git( '1.7.4.1' );
+	test_requires_git( '1.7.4.1' );
 	plan( tests => scalar( @$tests ) );
 
 	foreach my $test ( @$tests )

--- a/t/01-git_version.t
+++ b/t/01-git_version.t
@@ -4,11 +4,11 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
-has_git();
+test_requires_git();
 
 plan( tests => 2 );
 

--- a/t/05-Terminal/10-new.t
+++ b/t/05-Terminal/10-new.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Terminal;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/05-Terminal/20-get_encoding.t
+++ b/t/05-Terminal/20-get_encoding.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Terminal;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 4 );
 
 can_ok(

--- a/t/05-Terminal/30-is_interactive.t
+++ b/t/05-Terminal/30-is_interactive.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Terminal;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/05-Terminal/40-is_utf8.t
+++ b/t/05-Terminal/40-is_utf8.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Terminal;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/05-Terminal/50-get_width.t
+++ b/t/05-Terminal/50-get_width.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Terminal;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 5 );
 
 can_ok(

--- a/t/10-new.t
+++ b/t/10-new.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 7 );
 
 can_ok(

--- a/t/11-clone.t
+++ b/t/11-clone.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 5 );
 
 can_ok(

--- a/t/12-force_non_interactive.t
+++ b/t/12-force_non_interactive.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 8 );
 
 can_ok(

--- a/t/13-Config/20-get_regex.t
+++ b/t/13-Config/20-get_regex.t
@@ -8,12 +8,12 @@ use App::GitHooks::Test;
 use App::GitHooks::Utils;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # Regex test key.
 my $key_name = 'regex';

--- a/t/14-Utils/10-get_project_prefixes.t
+++ b/t/14-Utils/10-get_project_prefixes.t
@@ -8,12 +8,12 @@ use App::GitHooks::Test;
 use App::GitHooks::Utils;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # List of tests to run.
 my $tests =

--- a/t/14-Utils/12-get_project_prefix_regex.t
+++ b/t/14-Utils/12-get_project_prefix_regex.t
@@ -8,12 +8,12 @@ use App::GitHooks::Test;
 use App::GitHooks::Utils;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # List of tests to run.
 my $tests =

--- a/t/14-Utils/14-get_ticket_id_from_commit_regex.t
+++ b/t/14-Utils/14-get_ticket_id_from_commit_regex.t
@@ -8,12 +8,12 @@ use App::GitHooks::Test;
 use App::GitHooks::Utils;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # List of tests to run.
 my $tests =

--- a/t/14-Utils/20-get_ticket_id_from_branch_name.t
+++ b/t/14-Utils/20-get_ticket_id_from_branch_name.t
@@ -9,11 +9,12 @@ use App::GitHooks::Utils;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # Define tests.
 my $tests =

--- a/t/17-CommitMessage/10-new.t
+++ b/t/17-CommitMessage/10-new.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 5 );
 
 can_ok(

--- a/t/17-CommitMessage/11-get_app.t
+++ b/t/17-CommitMessage/11-get_app.t
@@ -7,12 +7,12 @@ use App::GitHooks::CommitMessage;
 use Scalar::Util qw();
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 4 );
 
 ok(

--- a/t/17-CommitMessage/13-get_original_message.t
+++ b/t/17-CommitMessage/13-get_original_message.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/17-CommitMessage/14-get_message.t
+++ b/t/17-CommitMessage/14-get_message.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/17-CommitMessage/15-get_lines.t
+++ b/t/17-CommitMessage/15-get_lines.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Deep;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 my $tests =
 [

--- a/t/17-CommitMessage/20-get_summary.t
+++ b/t/17-CommitMessage/20-get_summary.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/17-CommitMessage/25-update_message.t
+++ b/t/17-CommitMessage/25-update_message.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 5 );
 
 can_ok(

--- a/t/17-CommitMessage/30-is_empty.t
+++ b/t/17-CommitMessage/30-is_empty.t
@@ -5,12 +5,12 @@ use warnings;
 
 use App::GitHooks::CommitMessage;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 my $tests =
 [

--- a/t/17-CommitMessage/35-has_changed.t
+++ b/t/17-CommitMessage/35-has_changed.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::CommitMessage;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 5 );
 
 can_ok(

--- a/t/20-run.t
+++ b/t/20-run.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks;
 use Capture::Tiny;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 4 );
 
 can_ok(

--- a/t/21-run-dash.t
+++ b/t/21-run-dash.t
@@ -29,12 +29,12 @@ use App::GitHooks::Test;
 use Capture::Tiny;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 # Force a clean githooks config to ensure repeatable test conditions.

--- a/t/22-run-die.t
+++ b/t/22-run-die.t
@@ -29,12 +29,12 @@ use App::GitHooks::Test;
 use Capture::Tiny;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 # Force a clean githooks config to ensure repeatable test conditions.

--- a/t/40-Plugin/03-get_file_check_description.t
+++ b/t/40-Plugin/03-get_file_check_description.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::Plugin;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 2 );
 
 can_ok(

--- a/t/40-Plugin/20-get_name.t
+++ b/t/40-Plugin/20-get_name.t
@@ -6,12 +6,12 @@ use warnings;
 use App::GitHooks::Plugin;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 6 );
 
 can_ok(

--- a/t/40-Plugin/CustomReply/03-get_file_check_description.t
+++ b/t/40-Plugin/CustomReply/03-get_file_check_description.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Plugin::Test::CustomReply;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/40-Plugin/CustomReply/05-get_file_pattern.t
+++ b/t/40-Plugin/CustomReply/05-get_file_pattern.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
@@ -19,7 +19,7 @@ use App::GitHooks::Plugin::Test::CustomReply;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 2 );
 
 can_ok(

--- a/t/40-Plugin/PrintSTDERR/03-get_file_check_description.t
+++ b/t/40-Plugin/PrintSTDERR/03-get_file_check_description.t
@@ -6,13 +6,13 @@ use warnings;
 use App::GitHooks::Plugin::Test::PrintSTDERR;
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 3 );
 
 can_ok(

--- a/t/40-Plugin/PrintSTDERR/05-get_file_pattern.t
+++ b/t/40-Plugin/PrintSTDERR/05-get_file_pattern.t
@@ -11,7 +11,7 @@ use strict;
 use warnings;
 
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 use Test::Type;
 
@@ -19,7 +19,7 @@ use App::GitHooks::Plugin::Test::PrintSTDERR;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 2 );
 
 can_ok(

--- a/t/45-Hook/10-run.t
+++ b/t/45-Hook/10-run.t
@@ -12,12 +12,12 @@ use App::GitHooks;
 # External dependencies.
 use Test::Exception;
 use Test::FailWarnings -allow_deps => 1;
-use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 plan( tests => 6 );
 
 can_ok(

--- a/t/90-githooks/10-commands.t
+++ b/t/90-githooks/10-commands.t
@@ -6,11 +6,12 @@ use warnings;
 use File::Spec;
 use Test::FailWarnings -allow_deps => 1;
 use Test::Git;
+use Test::Requires::Git;
 use Test::More;
 
 
 # Require git.
-has_git( '1.7.4.1' );
+test_requires_git( '1.7.4.1' );
 
 # Declare tests.
 my $tests =


### PR DESCRIPTION
Test::Git::has_git is obsolete and replaced by
Test::Requires::Git::test_requires_git.